### PR TITLE
Fix certificate issue related to helm upgrade

### DIFF
--- a/charts/telegraf-operator/templates/_helpers.tpl
+++ b/charts/telegraf-operator/templates/_helpers.tpl
@@ -105,7 +105,7 @@ metadata:
   labels:
     {{- include "telegraf-operator.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   tls.crt: {{ $cert.Cert | b64enc }}

--- a/charts/telegraf-operator/templates/deployment.yaml
+++ b/charts/telegraf-operator/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     metadata:
       labels:
         {{- include "telegraf-operator.selectorLabels" . | nindent 8 }}
+{{- if eq .Values.certManager.enable false }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/tls.yml") . | sha256sum }}
+{{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
After helm upgrade for non cert manager installation, the ca in webhook is updated, but secret left unchanged what leads to tls errors. This PR additionally add annotations (as recommended in [official documentation](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)) to reload deployment in case of secret change